### PR TITLE
typo in _merge of kube_config.py

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -740,7 +740,7 @@ class KubeConfigMerger:
                     break
             else:
                 self.config_merged.value[item].append(ConfigNode(
-                    '{}/{}'.format(path, new_item), new_item, path))
+                    '{}/{}'.format(path, new_item['name']), new_item, path))
 
     def save_changes(self):
         for path in self.paths:


### PR DESCRIPTION
this broke parsing of my kubeconfig

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
